### PR TITLE
Remove echos for env vars and debug messages during startup

### DIFF
--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -70,10 +70,9 @@ RUN mkdir -p /kafka-connect-sqs \
 
 FROM confluentinc/cp-kafka-connect-base:5.1.1
 
-RUN sed -i 's/PASSWORD|JAAS_CONFIG/PASSWORD|JAAS_CONFIG|BASIC_AUTH_USER_INFO/' /etc/confluent/docker/bash-config
-
 RUN groupadd -g 1000 connect \
- && useradd -r -m -u 1000 -g connect connect
+ && useradd -r -m -u 1000 -g connect connect \
+ && sed -i 's/PASSWORD|JAAS_CONFIG/PASSWORD|JAAS_CONFIG|BASIC_AUTH_USER_INFO/' /etc/confluent/docker/bash-config
 
 ENV PROMETHEUS_JMX_EXPORTER_PORT=9011
 ENV PROMETHEUS_JMX_EXPORTER_CONF=/etc/jmx_exporter/kafka_connect.yaml

--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -70,8 +70,7 @@ RUN mkdir -p /kafka-connect-sqs \
 
 FROM confluentinc/cp-kafka-connect-base:5.1.1
 
-RUN sed -i 's/show_env/#show_env/' /etc/confluent/docker/run && \
-    sed -i 's/echo/#echo/' /etc/confluent/docker/run
+RUN sed -i 's/PASSWORD|JAAS_CONFIG/PASSWORD|JAAS_CONFIG|BASE_AUTH_USER_INFO/' /etc/confluent/docker/bash-config
 
 RUN groupadd -g 1000 connect \
  && useradd -r -m -u 1000 -g connect connect

--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -70,6 +70,9 @@ RUN mkdir -p /kafka-connect-sqs \
 
 FROM confluentinc/cp-kafka-connect-base:5.1.1
 
+RUN sed -i 's/show_env/#show_env/' /etc/confluent/docker/run && \
+    sed -i 's/echo/#echo/' /etc/confluent/docker/run
+
 RUN groupadd -g 1000 connect \
  && useradd -r -m -u 1000 -g connect connect
 

--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p /kafka-connect-sqs \
 
 FROM confluentinc/cp-kafka-connect-base:5.1.1
 
-RUN sed -i 's/PASSWORD|JAAS_CONFIG/PASSWORD|JAAS_CONFIG|BASE_AUTH_USER_INFO/' /etc/confluent/docker/bash-config
+RUN sed -i 's/PASSWORD|JAAS_CONFIG/PASSWORD|JAAS_CONFIG|BASIC_AUTH_USER_INFO/' /etc/confluent/docker/bash-config
 
 RUN groupadd -g 1000 connect \
  && useradd -r -m -u 1000 -g connect connect


### PR DESCRIPTION
We don't need all the debug messages at docker start, and the env vars could contain sensitive information that we don't want to print out.